### PR TITLE
fix: https polyfill for react-scripts > 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   },
   "lint-staged": {
     "*.ts": "eslint --cache --fix"
+  },
+  "dependencies": {
+    "https": "^1.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  "compilerOptions": {
-    "declaration": true,
-    "target": "ES2015",
-    "module": "commonjs",
-    "outDir": "dist",
-    "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true
-  },
-  "exclude": ["node_modules", "test", "__snapshots__", "lib"]
+	"compilerOptions": {
+		"declaration": true,
+		"target": "ES2015",
+		"module": "commonjs",
+		"outDir": "dist",
+		"rootDir": "src",
+		"strict": true,
+		"esModuleInterop": true,
+		"types": ["node", "jest"]
+	},
+	"exclude": ["node_modules", "test", "__snapshots__", "lib"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,6 +2547,11 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
+  integrity sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q=
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"


### PR DESCRIPTION
fix: react-scripts > 5 uses newer webpack, which errors out about polyfills