### PR TITLE
feat: add extraHTTPSOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
   "lint-staged": {
     "*.ts": "eslint --cache --fix"
   },
-  "packageManager": "yarn@3.2.4"
+  "packageManager": "yarn@3.2.4",
+  "dependencies": {
+    "https": "^1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
   "lint-staged": {
     "*.ts": "eslint --cache --fix"
   },
-  "dependencies": {
-    "https": "^1.0.0"
-  },
   "packageManager": "yarn@3.2.4"
 }

--- a/src/CoinGeckoClient.ts
+++ b/src/CoinGeckoClient.ts
@@ -65,7 +65,7 @@ export class CoinGeckoClient {
    */
   private async httpGet<T>(url: string) {
     const { host, pathname, search } = new URL(url);
-    const options = {
+    const options: https.RequestOptions = {
       host,
       path: pathname + search,
       method: "GET",
@@ -74,6 +74,7 @@ export class CoinGeckoClient {
         Accept: "application/json",
       },
       timeout: this.options.timeout, // in ms
+      ...this.options.extraHTTPSOptions,
     };
     const parseJson = (input: string) => {
       try {

--- a/src/Interface.ts
+++ b/src/Interface.ts
@@ -1,3 +1,4 @@
+import { RequestOptions } from 'https';
 import { PLATFORMS } from './Enum';
 
 export interface PingResponse {
@@ -536,7 +537,8 @@ export type GlobalDefiResponse = ResponseWithData<GlobalDefiData>;
 
 export interface Options {
   timeout?: number,
-  autoRetry?: boolean
+  autoRetry?: boolean,
+  extraHTTPSOptions?: RequestOptions
 }
 
 export interface HttpResponse<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,7 +2195,6 @@ __metadata:
     eslint-plugin-import: ^2.27.4
     eslint-plugin-jest: ^27.2.1
     gh-pages: ^3.2.3
-    https: ^1.0.0
     husky: ^8.0.3
     jest: ^29.3.1
     lint-staged: ^13.1.0
@@ -3994,13 +3993,6 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
-  languageName: node
-  linkType: hard
-
-"https@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "https@npm:1.0.0"
-  checksum: ccea8a8363a018d4b241db7748cff3a85c9f5b71bf80639e9c37dc6823f590f35dda098b80b726930e9f945387c8bfd6b1461df25cab5bf65a31903d81875b5d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,6 +2195,7 @@ __metadata:
     eslint-plugin-import: ^2.27.4
     eslint-plugin-jest: ^27.2.1
     gh-pages: ^3.2.3
+    https: ^1.0.0
     husky: ^8.0.3
     jest: ^29.3.1
     lint-staged: ^13.1.0
@@ -3993,6 +3994,13 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
+  languageName: node
+  linkType: hard
+
+"https@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "https@npm:1.0.0"
+  checksum: ccea8a8363a018d4b241db7748cff3a85c9f5b71bf80639e9c37dc6823f590f35dda098b80b726930e9f945387c8bfd6b1461df25cab5bf65a31903d81875b5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hey! I've added extraHTTPSOptions, it allows for more customization on the request, like using different headers.

and also, `https` is built-in into node, no need for that dummy dependency.